### PR TITLE
Add direct download links to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ This contains slide decks of various presentations I have given.
 
 Presentations:
 
-1. "Rules to Hack By" - OffensiveCon 2022 keynote (Berlin)
-2. "Security Technology Arms Race" - Hack in the Box 2021 keynote (Virtual)
-3. "What's in a Jailbreak?" - BSidesCbr 2019 keynote (Canberra)
-4. "The (Memory) Safety Dance" - SAS 2017 keynote (St Marteen)
+1. "[Rules to Hack By][offensivecon2022]" - OffensiveCon 2022 keynote (Berlin)
+2. "[Security Technology Arms Race][hitb2021]" - Hack in the Box 2021 keynote (Virtual)
+3. "[What's in a Jailbreak?][bsides2019]" - BSidesCbr 2019 keynote (Canberra)
+4. "[The (Memory) Safety Dance][sas2017]" - SAS 2017 keynote (St Marteen)
+
+[offensivecon2022]:https://github.com/mdowd79/presentations/raw/67b6395edccb33ffa29e3e50b61c7e90e1de5aef/offensivecon2022_mdowd_final.pdf
+[hitb2021]:https://github.com/mdowd79/presentations/raw/67b6395edccb33ffa29e3e50b61c7e90e1de5aef/hitb-dowd-final.pdf
+[bsides2019]:https://github.com/mdowd79/presentations/raw/67b6395edccb33ffa29e3e50b61c7e90e1de5aef/bsides2019-dowd-final.pdf
+[sas2017]:https://github.com/mdowd79/presentations/raw/67b6395edccb33ffa29e3e50b61c7e90e1de5aef/sas2017-dowd-final.pdf


### PR DESCRIPTION
Using full path persistent links to the "raw" files.

A minor convenience to save a few clicks.

Thank you for making these available.
